### PR TITLE
Workaround for splash screen freeze on Nokia 2.3 (Android 11)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:node="merge">
+        <activity android:name=".SplashActivity"></activity>
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"
@@ -116,7 +117,7 @@
             android:exported="false" />
         <service
             android:name=".location.GraphHopperService"
-            android:exported="false"/>
+            android:exported="false" />
         <service
             android:name=".maps.MapService"
             android:exported="false" />

--- a/app/src/main/java/mobi/maptrek/MainActivity.java
+++ b/app/src/main/java/mobi/maptrek/MainActivity.java
@@ -791,6 +791,8 @@ public class MainActivity extends BasePluginActivity implements ILocationListene
 
         if (lastIntroduction < IntroductionActivity.CURRENT_INTRODUCTION)
             startActivity(new Intent(this, IntroductionActivity.class));
+        else
+            startActivity(new Intent(this, SplashActivity.class));
     }
 
     protected void onNewIntent(Intent intent) {

--- a/app/src/main/java/mobi/maptrek/SplashActivity.java
+++ b/app/src/main/java/mobi/maptrek/SplashActivity.java
@@ -1,0 +1,28 @@
+package mobi.maptrek;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import org.oscim.backend.canvas.Color;
+
+import static mobi.maptrek.R.color.*;
+
+public class SplashActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_splash);
+        getWindow().getDecorView().setBackgroundColor(Color.TRANSPARENT);
+
+        final android.os.Handler handler = new android.os.Handler();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                SplashActivity.this.finish();
+            }
+        }, 1000);
+    }
+}

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SplashActivity">
+</LinearLayout>


### PR DESCRIPTION
As mentioned I'm having big troubles on my Nokia 2.3 since it updated to Android 11.
Its no data issue as the problem persisted after removing my SD card, testing internal memory and factory reset of the Nokia.

Somehow the splash screen/icon doesn't disappear in the main activity. The only working and stable solution I've found is to show another activity.

It might have something to do with `setSystemUiVisibility` being depreciated in API 30. You use it in MainActivity.java:747 with the comment `Remove splash from background` which I reckon is to remove the splash screen...

Let me know what you think or what you'd like to do.

I'm happy to try other solutions you wonna try.

Soko