### PR TITLE
Enable current map restoration with Online/OfflineTileSource maps.

### DIFF
--- a/app/src/main/java/mobi/maptrek/Configuration.java
+++ b/app/src/main/java/mobi/maptrek/Configuration.java
@@ -279,7 +279,7 @@ public class Configuration {
             String[] filenames = new String[mapFiles.size()];
             int i = 0;
             for (MapFile mapFile : mapFiles) {
-                filenames[i] = mapFile.tileSource.getOption("path");
+                filenames[i] = mapFile.id;
                 i++;
             }
             saveString(PREF_BITMAP_MAP, TextUtils.join(";", filenames));

--- a/app/src/main/java/mobi/maptrek/maps/MapFile.java
+++ b/app/src/main/java/mobi/maptrek/maps/MapFile.java
@@ -24,6 +24,7 @@ import org.oscim.tiling.TileSource;
 
 public class MapFile {
     public String name;
+    public String id;
     public BoundingBox boundingBox;
     public TileSource tileSource;
     public transient TileLayer tileLayer;
@@ -32,8 +33,9 @@ public class MapFile {
     MapFile() {
     }
 
-    public MapFile(String name) {
+    public MapFile(String name, String id) {
         this.name = name;
+        this.id = id;
     }
 
     /**

--- a/app/src/main/java/mobi/maptrek/maps/MapIndex.java
+++ b/app/src/main/java/mobi/maptrek/maps/MapIndex.java
@@ -102,6 +102,7 @@ public class MapIndex implements Serializable {
                 if (result.isSuccess()) {
                     SQLiteMapInfo info = tileSource.getMapInfo();
                     mapFile.name = info.name;
+                    mapFile.id = tileSource.getOption("path");
                     mapFile.boundingBox = info.boundingBox;
                     mapFile.tileSource = tileSource;
                     tileSource.close();
@@ -133,7 +134,7 @@ public class MapIndex implements Serializable {
 
             List<OnlineTileSource> tileSources = OnlineTileSourceFactory.fromPlugin(mContext, packageManager, provider);
             for (OnlineTileSource tileSource : tileSources) {
-                MapFile mapFile = new MapFile(tileSource.getName());
+                MapFile mapFile = new MapFile(tileSource.getName(), tileSource.getUri());
                 mapFile.tileSource = tileSource;
                 mapFile.boundingBox = WORLD_BOUNDING_BOX;
                 //TODO Implement tile cache expiration
@@ -160,7 +161,7 @@ public class MapIndex implements Serializable {
 
             List<OfflineTileSource> tileSources = OfflineTileSourceFactory.fromPlugin(mContext, packageManager, provider);
             for (OfflineTileSource tileSource : tileSources) {
-                MapFile mapFile = new MapFile(tileSource.getName());
+                MapFile mapFile = new MapFile(tileSource.getName(), tileSource.getUri());
                 mapFile.tileSource = tileSource;
                 mapFile.boundingBox = WORLD_BOUNDING_BOX;
                 mMaps.add(mapFile);
@@ -169,13 +170,13 @@ public class MapIndex implements Serializable {
     }
 
     @NonNull
-    public ArrayList<MapFile> getMaps(@Nullable String[] filenames) {
+    public ArrayList<MapFile> getMaps(@Nullable String[] ids) {
         ArrayList<MapFile> maps = new ArrayList<>();
-        if (filenames == null)
+        if (ids == null)
             return maps;
-        for (String filename : filenames) {
+        for (String id : ids) {
             for (MapFile map : mMaps) {
-                if (filename.equals(map.tileSource.getOption("path")))
+                if (id.equals(map.id))
                     maps.add(map);
             }
         }

--- a/app/src/main/java/mobi/maptrek/maps/offline/OfflineTileSource.java
+++ b/app/src/main/java/mobi/maptrek/maps/offline/OfflineTileSource.java
@@ -166,4 +166,8 @@ public class OfflineTileSource extends TileSource {
     public String getName() {
         return mName;
     }
+
+    public String getUri() {
+        return mUri;
+    }
 }

--- a/app/src/main/java/mobi/maptrek/maps/online/OnlineTileSource.java
+++ b/app/src/main/java/mobi/maptrek/maps/online/OnlineTileSource.java
@@ -140,4 +140,8 @@ public class OnlineTileSource extends BitmapTileSource {
     public String getName() {
         return mName;
     }
+
+    public String getUri() {
+        return mUri;
+    }
 }


### PR DESCRIPTION
Current map had been failing to be restored on startup with `OnlineTileSource` and `OfflineTileSource` maps. This is because TileSource.getOption("path") was used as identifier though not available with those sources.

Instead, I added an identifier in MapFile: it's still TileSource.getOption("path") for imported maps, whereas the content URI is used with OnlineTileSource and OfflineTileSource.