### PR TITLE
Support plugins providing no map

### DIFF
--- a/app/src/main/java/mobi/maptrek/maps/plugin/PluginTileSourceFactory.java
+++ b/app/src/main/java/mobi/maptrek/maps/plugin/PluginTileSourceFactory.java
@@ -199,7 +199,11 @@ public final class PluginTileSourceFactory {
             if (cursor == null)
                 return maps;
 
-            cursor.moveToFirst();
+            if (!cursor.moveToFirst()) {
+                cursor.close();
+                return maps;
+            }
+
             do {
                 // map name
                 int nameIdx = cursor.getColumnIndex(PluginTileSourceContract.COLUMN_NAME);


### PR DESCRIPTION
Dynamic map providers can sometimes provide no map (for instance before the user has added any). I think it's graceful to handle this case this in Trekarta.